### PR TITLE
Create a clipboard trait

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -8,7 +8,7 @@ pub trait Clipboard {
     /// Replace the current stored data in the clipboard with `content`
     fn copy<T>(&mut self, content: T)
     where
-        T: AsRef<str>;
+        T: Into<String>;
 }
 
 /// Just  a wrapper around a String for now... maybe it'll hold formatting someday.
@@ -31,8 +31,8 @@ impl Clipboard for MemoryClipboard {
 
     fn copy<T>(&mut self, content: T)
     where
-        T: AsRef<str>,
+        T: Into<String>,
     {
-        self.inner = String::from(content.as_ref());
+        self.inner = content.into();
     }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,11 +1,38 @@
-//Just  a wrapper around a String for now... maybe it'll hold formatting someday.
-pub struct Clipboard {
+// TODO: create an implementation of clipboard that interfaces with the operating system
+
+/// The clipboard trait is responsible for storing and retrieving a buffer of characters
+pub trait Clipboard {
+    /// Return the contents of the clipboard as a string
+    fn paste(&self) -> String;
+
+    /// Replace the current stored data in the clipboard with `content`
+    fn copy<T>(&mut self, content: T)
+    where
+        T: AsRef<str>;
+}
+
+/// Just  a wrapper around a String for now... maybe it'll hold formatting someday.
+pub struct MemoryClipboard {
     pub inner: String
 }
 
-impl Clipboard {
+/// MemoryClipboard is an in memory implementation of the clipboard trait
+impl MemoryClipboard {
     pub fn new() -> Self {
         let inner = String::from("");
-        Clipboard { inner }
+        Self { inner }
+    }
+}
+
+impl Clipboard for MemoryClipboard {
+    fn paste(&self) -> String {
+        return self.inner.clone();
+    }
+
+    fn copy<T>(&mut self, content: T)
+    where
+        T: AsRef<str>,
+    {
+        self.inner = String::from(content.as_ref());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::{LineWriter, Write};
 use log::{debug, info, warn};
 use std::path::Path;
-use rust_ed::clipboard::Clipboard;
+use rust_ed::clipboard::{Clipboard, MemoryClipboard};
 
 
 fn main() {
@@ -24,7 +24,7 @@ fn main() {
 
         cursor.show().expect("Cannot display cursor");
         let mut screen = Screen::new(80, 24);
-        let mut clipboard = Clipboard::new();
+        let mut clipboard = MemoryClipboard::new();
         //let mut selection = Selection::new(&screen);
         loop {
             let event = sync_stdin.next();
@@ -39,7 +39,7 @@ fn main() {
     }
 }
 
-fn process_input_event(key_event: InputEvent, screen: &mut Screen, clipboard: &mut Clipboard) -> bool {
+fn process_input_event(key_event: InputEvent, screen: &mut Screen, clipboard: &mut impl Clipboard) -> bool {
     match key_event {
         InputEvent::Keyboard(k) => {
             match k {
@@ -90,10 +90,10 @@ fn process_input_event(key_event: InputEvent, screen: &mut Screen, clipboard: &m
                     //screen.select_all();
                 },
                 KeyEvent::Ctrl('c') => {
-                    clipboard.inner = String::from(screen.get_highlight());
+                    clipboard.copy(String::from(screen.get_highlight()));
                 },
                 KeyEvent::Ctrl('v') => {
-                    screen.write(clipboard.inner.as_str());
+                    screen.write(clipboard.paste().as_str());
                 },
                 KeyEvent::Ctrl('s') => {
                     screen.save();


### PR DESCRIPTION
Creates a new trait that defines the methods `copy` and `paste`.

TODO: If your operating system isn't supported by the clipboard library it should fall back to using an in-memory implementation.

This should be changed to return to return a `Result` in the future because there is chance your clipboard contents get rejected by the OS.